### PR TITLE
feat: add governance docs

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -12,6 +12,7 @@ Users are the foundation of the Bank-Vaults community. They utilize the project 
 - Report issues and suggest improvements
 - Participate in discussions on our communication channels
 - Contribute to documentation by reporting unclear or outdated sections
+- Add themselves to our [adopters list](https://github.com/bank-vaults/bank-vaults/blob/main/ADOPTERS.md)
 
 ### Contributors
 
@@ -47,7 +48,7 @@ We welcome contributions from everyone. To get started:
 
 1. Fork the repository
 2. Create a new branch for your changes
-3. Make your changes and commit them with clear, descriptive messages
+3. Make your changes and commit them with clear, descriptive messages, signed off by the author
 4. Open a pull request with a detailed description of your changes
 
 All contributions will be reviewed by maintainers and/or experienced contributors.
@@ -58,7 +59,7 @@ Bank-Vaults adheres to its [Code of Conduct](https://bank-vaults.dev/docs/code-o
 
 ## Communication Channels
 
-- GitHub Issues, Pull requests, and Discussions.
+- GitHub Issues, Pull requests, and Discussions
 - [Slack channel](https://cloud-native.slack.com/archives/C078PHYK38W) for real-time communication
 
 ## Roadmap and Release Process

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,67 @@
+# Bank-Vaults Project Governance
+
+Bank-Vaults is an open source project dedicated to simplifying the complex world of secret management in the Cloud Native ecosystem and on Kubernetes. This document outlines the project's governance structure and how community members can contribute and participate in decision-making processes.
+
+## Community Roles
+
+### Users
+
+Users are the foundation of the Bank-Vaults community. They utilize the project in their environments and provide valuable feedback. We encourage users to:
+
+- Share their experiences with Bank-Vaults
+- Report issues and suggest improvements
+- Participate in discussions on our communication channels
+- Contribute to documentation by reporting unclear or outdated sections
+
+### Contributors
+
+Contributors actively help improve Bank-Vaults. Anyone can become a contributor by:
+
+- Submitting pull requests for bug fixes or new features
+- Improving documentation
+- Helping other users in community forums
+- Reviewing pull requests
+- Writing blog posts or giving talks about Bank-Vaults
+
+Regular contributors may be invited to join the `contributors` team, granting them additional access and responsibilities.
+
+### Maintainers
+
+Maintainers are responsible for the overall direction and quality of the project. Their duties include:
+
+- Reviewing and merging pull requests
+- Triaging issues
+- Guiding architectural decisions
+- Managing releases
+- Ensuring the project adheres to security best practices
+
+New maintainers are nominated by existing maintainers and approved through a consensus process and will be added to the `maintainers` team.
+
+## Decision Making
+
+Bank-Vaults follows a consensus-seeking decision-making process. For most decisions, we strive for agreement among maintainers. If consensus cannot be reached, the project lead (or a designated decision-maker) will make the final call.
+
+## Contributing
+
+We welcome contributions from everyone. To get started:
+
+1. Fork the repository
+2. Create a new branch for your changes
+3. Make your changes and commit them with clear, descriptive messages
+4. Open a pull request with a detailed description of your changes
+
+All contributions will be reviewed by maintainers and/or experienced contributors.
+
+## Code of Conduct
+
+Bank-Vaults adheres to its [Code of Conduct](https://bank-vaults.dev/docs/code-of-conduct/)
+
+## Communication Channels
+
+- GitHub Issues, Pull requests, and Discussions.
+- [Slack channel](https://cloud-native.slack.com/archives/C078PHYK38W) for real-time communication
+
+## Roadmap and Release Process
+
+- The project roadmap is maintained in the [GitHub organization](https://github.com/orgs/bank-vaults/projects/5).
+- Releases are managed by maintainers and follow semantic versioning.


### PR DESCRIPTION
- Adds written open Governance, requested on the [CNCF project onboarding checklist](https://github.com/cncf/sandbox/issues/142)